### PR TITLE
chore: add git commit hash for deploy purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coverage": "c8 --all --exclude typechain* --exclude coverage --exclude dist --exclude src/proto* --exclude test npm test && c8 report --all --exclude typechain* --exclude coverage --exclude dist --exclude test --exclude src/proto* -r html",
     "build": "yarn clean && yarn tsc -p tsconfig-build.json",
     "prepare": "husky install",
-    "start": "node dist/esm/src/index.js"
+    "start": "node --experimental-specifier-resolution=node ./dist/esm/src/index.js"
   },
   "files": [
     "dist/"

--- a/src/controllers/HealthController.ts
+++ b/src/controllers/HealthController.ts
@@ -1,0 +1,20 @@
+import { AuthRequest } from '../types';
+import { NextFunction, Response } from 'express';
+import gitCommit from 'src/gitCommit';
+
+export class HealthController {
+  public async getBasicHealth(
+    req: AuthRequest,
+    res: Response,
+    next: NextFunction
+  ) {
+    try {
+      console.log('we are here');
+      res.json({ success: true, commit: gitCommit.hash });
+    } catch (e) {
+      next(e);
+    }
+  }
+}
+
+export default new HealthController();

--- a/src/gitCommit.ts
+++ b/src/gitCommit.ts
@@ -1,0 +1,4 @@
+// This file will be updated automatically with actual git commit hash.
+// So that we know what version of code is running on test/prod environment.
+// You can get this information from API end-point "GET /api/health".
+export default { hash: '' };

--- a/src/router/health.ts
+++ b/src/router/health.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import healthController from '../controllers/HealthController';
+
+export default (router: Router): void => {
+  router.get('/health', healthController.getBasicHealth);
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,12 +5,14 @@ import usersRoutes from './users';
 import proxyRoutes from './proxy';
 import bookingRoutes from './booking';
 import hotelRoutes from './hotel';
+import healthRoutes from './health';
 
 const routes: RouterInitializer[] = [
   usersRoutes,
   proxyRoutes,
   bookingRoutes,
-  hotelRoutes
+  hotelRoutes,
+  healthRoutes
 ];
 
 const router = Router();

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -438,3 +438,11 @@ paths:
         500:
           description: Some server error
   #end hotels
+
+  #health
+  /health:
+    get:
+      responses:
+        200:
+          description: It's ok
+  #end health


### PR DESCRIPTION
This will enable you to visit the end-point `GET /api/health` and see what commit is currently deployed on `test` and `prod` environment.