### PR TITLE
feat/provider-id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,4 @@ SENDGRID_EMAIL_TEMPLATE_ID={template_id}
 APP_ENVIRONMENT={development,test,production}
 REWARD_PERCENTAGE=6
 COINGECKO_URL=https://api.coingecko.com/api/v3
+SERVICE_PROVIDER_ID={unique_provider_id} # 0x394e5c06a83eeea7fd8e0e50bb1ff1f13bec1a4e353a9a0f6db9dea030bcbef3

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/yamljs": "^0.2.31",
     "@web-std/file": "^3.0.2",
     "@windingtree/glider-types": "1.13.0",
-    "@windingtree/win-commons": "^1.3.0",
+    "@windingtree/win-commons": "^1.4.0",
     "@windingtree/win-pay": "^1.1.0",
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,8 @@ checkEnvVariables([
   'SENDGRID_EMAIL_TEMPLATE_ID',
   'APP_ENVIRONMENT',
   'REWARD_PERCENTAGE',
-  'COINGECKO_URL'
+  'COINGECKO_URL',
+  'SERVICE_PROVIDER_ID'
 ]);
 
 export enum AppMode {
@@ -114,3 +115,6 @@ export const rewardPercentage = Number(process.env.REWARD_PERCENTAGE);
 export const coinGeckoURL = String(process.env.COINGECKO_URL); // Note: Free API is limited to 50 calls/minute.
 export const tco2Precision = 1;
 export const tokenPrecision = 0;
+
+// Service provider Id
+export const serviceProviderId = process.env.SERVICE_PROVIDER_ID;

--- a/src/services/ProxyService.ts
+++ b/src/services/ProxyService.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosResponse } from 'axios';
-import { clientJwt, getUrlByKey, providersUrls } from '../config';
+import {
+  clientJwt,
+  getUrlByKey,
+  providersUrls,
+  serviceProviderId
+} from '../config';
 import hotelRepository from '../repositories/HotelRepository';
 import { makeCircumscribedSquare } from '../utils';
 import LogService from './LogService';
@@ -301,9 +306,7 @@ export class ProxyService {
     };
 
     data.serviceId = utils.id(data.offerId);
-    data.provider = utils.keccak256(
-      utils.formatBytes32String('win_win_provider')
-    );
+    data.provider = process.env.serviceProviderId;
 
     return data;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,10 +1435,10 @@
     "@windingtree/org.id-utils" "^1.0.0-beta.47"
     "@windingtree/org.json-schema" "1.0.2"
 
-"@windingtree/win-commons@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@windingtree/win-commons/-/win-commons-1.3.0.tgz#88e424b96cb0ea7c9497f28e1343dc9e1e47dc4c"
-  integrity sha512-SvJWfQY+82R0zZwv/rF3OMphxR/5Ps+ZkBkrKb4NBX9ULfzEQ1JD4YVKHff+QcfNRIb5BlXkOPmGnqG6YsnFuw==
+"@windingtree/win-commons@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@windingtree/win-commons/-/win-commons-1.4.0.tgz#37e88982b9f9663c4fc35c5d69765a500d065aa8"
+  integrity sha512-sywS12JCiovAJ6hWXTmSrs0LohNtUdbDKN2RB2J29sQXN2ChEqjldCmo218vYm1voP+5XVIkQDWrzXxNufuGuw==
   dependencies:
     ethers "^5.6.9"
 


### PR DESCRIPTION
This PR:

- add mandatory env variable `SERVICE_PROVIDER_ID`
- updated `@windingtree/win-commons` version; This version adds production config

BREAKING CHANGE:

Required in the backend production environment:

```
SERVICE_PROVIDER_ID=0x5e6994f76764ceb42c476a2505065a6170178a24c03d81c9f372563830001171
```
and in the staging environment:

```
SERVICE_PROVIDER_ID=0x394e5c06a83eeea7fd8e0e50bb1ff1f13bec1a4e353a9a0f6db9dea030bcbef3
```