### PR TITLE
fix: 🐛 Fixed missed provider value in priced offer

### DIFF
--- a/src/services/ProxyService.ts
+++ b/src/services/ProxyService.ts
@@ -306,7 +306,7 @@ export class ProxyService {
     };
 
     data.serviceId = utils.id(data.offerId);
-    data.provider = process.env.serviceProviderId;
+    data.provider = serviceProviderId;
 
     return data;
   }


### PR DESCRIPTION
This PR fixes the issue with missed provider Id in the priced offer response